### PR TITLE
Added tests for createAction 

### DIFF
--- a/src/lib/createAction.js
+++ b/src/lib/createAction.js
@@ -26,17 +26,26 @@ all options can either be a value, or a function that returns a value.
 if you define a function, it will receive options.params as an argument
 */
 
-export default (defaults = {}) => (opt = {}) => {
-  // merge our multitude of option objects together
-  // defaults = options defined in createAction
-  // opt = options specified in action creator
-  const options = mapValues(merge({}, opt, defaults), (v, k, { params }) => {
-    if (reserved.indexOf(k) !== -1) return v
+// merge our multitude of option objects together
+// defaults = options defined in createAction
+// opt = options specified in action creator
+const isReserved = (k) => reserved.indexOf(k) !== -1
+
+export const mergeOptions = (defaults, opt) => {
+  return mapValues(merge({}, opt, defaults), (v, k, { params }) => {
+    if (isReserved(k)) return v
     return result(v, params)
   })
+}
 
+// handle errors and pass the options into a callback
+export const handleOptions = (options, onSuccess) => {
   if (!options.method) throw new Error('Missing method')
   if (!options.endpoint) throw new Error('Missing endpoint')
+  return onSuccess(options)
+}
 
-  return sendRequest(options)
+export default (defaults = {}) => (opt = {}) => {
+  const options = mergeOptions(defaults, opt)
+  return handleOptions(options, sendRequest)
 }

--- a/test/createAction.js
+++ b/test/createAction.js
@@ -1,0 +1,85 @@
+/*global it: true, describe: true, beforeEach: true */
+/*eslint no-console: 0*/
+
+import { fromJS } from 'immutable'
+import should from 'should'
+import {  createAction } from '../src'
+import { mergeOptions, handleOptions } from '../src/lib/createAction'
+
+describe('createAction', () => {
+  it('should exist', (done) => {
+    should.exist(createAction)
+    done()
+  })
+  describe('mergeOptions', () => {
+    const opt = {
+      tail: true,
+      onResponse: () => 'response',
+      onError: () => 'error',
+      method: 'GET',
+      endpoint: (params) => `${params.string}/test`,
+      params: {
+        string:  '/other'
+      }
+    }
+
+    const defaults = {
+      tail: false,
+      collection: false
+    }
+
+    it('should exist', (done) => {
+      should.exist(mergeOptions)
+      done()
+    })
+    it('should apply defaults and convert non reserved functions to values', (done) => {
+      const result = mergeOptions(opt, defaults)
+      const expected = fromJS(opt).withMutations((updated) => {
+        updated.set('endpoint', '/other/test')
+        updated.set('collection', false)
+      })
+      should(result).be.deepEqual(expected.toJS())
+      done()
+    })
+  })
+  describe('handleOptions', () => {
+    let passedInOptions = null
+    const onSuccess = (options) => {
+      passedInOptions = options
+    }
+    beforeEach(() => {
+      passedInOptions = null
+    })
+    it('should exist', (done) => {
+      should.exist(handleOptions)
+      done()
+    })
+    it('should throw an error if endpoint isn\'t set', (done) =>{
+      should.throws(
+        () => {
+          handleOptions({ method: 'test' }, onSuccess)
+        },
+        /Missing endpoint/
+      )
+      done()
+    })
+    it('should throw an error if method isn\'t set', (done) =>{
+      should.throws(
+        () => {
+          handleOptions({ endpoint: 'test' }, onSuccess)
+        },
+        /Missing method/
+      )
+      done()
+    })
+    it('should pass options into onSuccess', (done) => {
+      const options = {
+        method: 'test',
+        endpoint: 'test'
+      }
+      handleOptions(options, onSuccess)
+      should(passedInOptions).be.deepEqual(options)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
The api hasn't changed at all, I just split out a few functions and exported them so I could test them directly instead of having to stub out sendRequest
