### PR TITLE
Event stream test

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "mocha": "^2.3.4",
     "mochify": "dylanfm/mochify.js",
     "rimraf": "^2.5.0",
-    "should": "^8.0.0"
+    "should": "^8.0.0",
+    "sinon": "^1.17.3"
   },
   "babel": {
     "presets": [

--- a/src/lib/createEventSource.js
+++ b/src/lib/createEventSource.js
@@ -57,6 +57,7 @@ const combineUrl = (endpoint, query) => {
   }
   return url.format(ay)
 }
+
 export default (opt, dispatch) => {
   const finalUrl = combineUrl(opt.endpoint, opt.query)
   const src = new EventSource(finalUrl, { withCredentials: opt.withCredentials })

--- a/src/lib/createEventSource.js
+++ b/src/lib/createEventSource.js
@@ -1,5 +1,6 @@
 import url from 'url'
 import entify from './entify'
+import eventHandlers from './eventHandlers.js'
 
 const handleMessage = (opt, dispatch, fn) => ({ data }) => {
   try {

--- a/src/lib/eventHandlers.js
+++ b/src/lib/eventHandlers.js
@@ -1,0 +1,3 @@
+export default {
+  
+}

--- a/src/lib/eventHandlers.js
+++ b/src/lib/eventHandlers.js
@@ -1,3 +1,11 @@
 export default {
-  
+  insert : {
+    
+  },
+  update: {
+
+  },
+  delete: {
+
+  }
 }

--- a/src/lib/eventHandlers.js
+++ b/src/lib/eventHandlers.js
@@ -1,11 +1,20 @@
 export default {
   insert : {
-    
+    normalized: (getEntities, prev, next, opt) => getEntities(next, opt),
+    raw: (prev, next) => next
   },
   update: {
-
+    normalized: (getEntities, prev, next, opt) => ({
+      prev: getEntities(prev, opt),
+      next : getEntities(next, opt)
+    }),
+    raw: (prev, next) => ({
+      prev,
+      next
+    })
   },
   delete: {
-
+    normalized: (getEntities, prev, next, opt) => getEntities(prev, opt),
+    raw: (prev) => prev
   }
 }

--- a/test/eventStreamTest.js
+++ b/test/eventStreamTest.js
@@ -38,19 +38,30 @@ describe('createEventSource', () => {
     const opt = { test: 1 }
     let dispatchStub = null
     beforeEach(() => {
-      dispatchStub = sinon.stub()
+      dispatchStub = sinon.stub();
     })
     it('should dispatch any JSON parsing errors', (done) => {
       const badResponse = {
         data: '{'
       }
       handleMessage(opt, dispatchStub, 'insert')(badResponse)
-      should(dispatchStub.calledWith({
-        type: 'tahoe.failure',
-        meta: opt,
-        payload: new Error('SyntaxError: Unexpected token u')
-      })).equal(true)
+      let passedIntoDispatch = dispatchStub.firstCall.args
+      const payload = passedIntoDispatch[0].payload
+      delete passedIntoDispatch[0]['payload']
+      should(passedIntoDispatch).deepEqual([ 
+        {
+          type: 'tahoe.failure',
+          meta: opt
+        } 
+      ])
+      should(payload instanceof Error).equal(true)
       done()
+
+      // should(dispatchStub.calledWith({
+
+      //   payload: new Error("JSON Parse error: Expected '}'")
+      // })).equal(true)
+      // done()
     })
   }) 
   describe('the dispatchMessageType helper', () => {

--- a/test/eventStreamTest.js
+++ b/test/eventStreamTest.js
@@ -2,11 +2,122 @@
 /*eslint no-console: 0*/
 
 import should from 'should'
-import createEventSource  from '../src/lib/createEventSource'
+import createEventSource, { handleMessage, dispatchMessageType, getPayload }  from '../src/lib/createEventSource'
+import sinon from 'sinon'
 
-describe.only('createEventSouce', () => {
-  it('should exist', (done) => {
-    should.exist(createEventSource)
-    done()
+describe.only('createEventSource', () => {
+  describe('the default function', () => {
+    const opt = {
+      endpoint: '/test',
+      query: {
+        query1: 'foo'
+      },
+      withCredentials: true
+    }
+    const dispatch = () => {}
+    let listenerStub = null
+    beforeEach(() => {
+      global.EventSource = sinon.stub()
+      listenerStub = sinon.stub()
+      global.EventSource.prototype.addEventListener = listenerStub
+    })
+    it('should exist', (done) => {
+      should.exist(createEventSource)
+      done()
+    })
+    it('should create an event source and add listeners', (done) => {
+      createEventSource(opt, dispatch)
+      should(EventSource.calledWith('/test?query1=foo', { withCredentials : true })).equal(true)
+      should(listenerStub.firstCall.calledWith('insert')).equal(true)
+      should(listenerStub.secondCall.calledWith('update')).equal(true)
+      should(listenerStub.thirdCall.calledWith('delete')).equal(true)
+      done()
+    })
   })
+  describe('the handle message helper', () => {
+    const opt = { test: 1 }
+    let dispatchStub = null
+    beforeEach(() => {
+      dispatchStub = sinon.stub()
+    })
+    it('should dispatch any JSON parsing errors', (done) => {
+      const badResponse = {
+        data: '{'
+      }
+      handleMessage(opt, dispatchStub, 'insert')(badResponse)
+      should(dispatchStub.calledWith({
+        type: 'tahoe.failure',
+        meta: opt,
+        payload: new Error('SyntaxError: Unexpected token u')
+      })).equal(true)
+      done()
+    })
+  }) 
+  describe('the dispatchMessageType helper', () => {
+    const opt = {
+      model: {}
+    }
+    const body = {
+      next : {
+        test: 1
+      }
+    }
+    let dispatchStub = null
+    const entifyStub = (body) => ({ entities : body })
+    beforeEach(() => {
+      dispatchStub = sinon.stub()
+    })
+    it('should get the correct type and payload and pass them into dispatch', (done) => {
+      dispatchMessageType(body, opt, dispatchStub, entifyStub, 'insert')
+      should(dispatchStub.firstCall.args).deepEqual([
+        {
+          type: 'tahoe.tail.insert',
+          meta: opt,
+          payload: {
+            normalized: { entities : body.next },
+            raw: body.next
+          }
+        }
+      ])
+      done()
+    })
+  }) 
+  describe('the getPayload helper', () => {
+    const opt = {
+      model: {}
+    }
+    const data = {
+      prev: { test: 'prev' },
+      next: { test: 'next' }
+    }
+    const getEntities = (body) => ({ entities : body })
+    it('should return the correct payload on delete', (done) =>{
+      should(getPayload(data, opt, getEntities, 'delete')).deepEqual({
+        normalized: {
+          entities: data.prev
+        },
+        raw: data.prev
+      })
+      done()
+    })
+    it('should return the correct payload on update', (done) =>{
+      should(getPayload(data, opt, getEntities, 'update')).deepEqual({
+        normalized: {
+          prev: { entities: data.prev },
+          next: { entities: data.next }
+        },
+        raw: data
+      })
+      done()
+    })
+    it('should set normalized as null if no opt.model is provided', (done) =>{
+      should(getPayload(data, {}, getEntities, 'delete')).deepEqual({
+        normalized: null,
+        raw: data.prev
+      })
+      done()
+    })
+  })
+
+  
 })

--- a/test/eventStreamTest.js
+++ b/test/eventStreamTest.js
@@ -56,12 +56,6 @@ describe('createEventSource', () => {
       ])
       should(payload instanceof Error).equal(true)
       done()
-
-      // should(dispatchStub.calledWith({
-
-      //   payload: new Error("JSON Parse error: Expected '}'")
-      // })).equal(true)
-      // done()
     })
   }) 
   describe('the dispatchMessageType helper', () => {

--- a/test/eventStreamTest.js
+++ b/test/eventStreamTest.js
@@ -1,0 +1,12 @@
+/*global it: true, describe: true, beforeEach: true */
+/*eslint no-console: 0*/
+
+import should from 'should'
+import createEventSource  from '../src/lib/createEventSource'
+
+describe.only('createEventSouce', () => {
+  it('should exist', (done) => {
+    should.exist(createEventSource)
+    done()
+  })
+})

--- a/test/eventStreamTest.js
+++ b/test/eventStreamTest.js
@@ -5,7 +5,7 @@ import should from 'should'
 import createEventSource, { handleMessage, dispatchMessageType, getPayload }  from '../src/lib/createEventSource'
 import sinon from 'sinon'
 
-describe.only('createEventSource', () => {
+describe('createEventSource', () => {
   describe('the default function', () => {
     const opt = {
       endpoint: '/test',


### PR DESCRIPTION
It required a little bit more refactoring for me to test this. I abstracted the payload handling code into its own function so I could test that directly without having to run all of handleMessage every time.  

The only thing I'm feeling a little iffy about is in the fact that I'm passing around getEntities as a call back, instead of calling entify directly, but that was somewhat of a kludge so that I could pass in a stub and not have to set up an actual model and entify it in the tests, which seemed unnecessarily complicated. 
