### PR TITLE
Add error response to onError 

### DIFF
--- a/src/lib/sendRequest.js
+++ b/src/lib/sendRequest.js
@@ -17,7 +17,7 @@ const createResponseHandler = ({ options, dispatch }) => {
         meta: options,
         payload: err
       })
-      if (options.onError) options.onError(err)
+      if (options.onError) options.onError(err, res)
       return
     }
 


### PR DESCRIPTION
since an endpoint can return both a 400 and an error message