### PR TITLE
Add option for a root global error to be set with redux-sutro

### DIFF
--- a/src/lib/sendRequest.js
+++ b/src/lib/sendRequest.js
@@ -15,6 +15,7 @@ const createResponseHandler = ({ options, dispatch, reject, resolve }) => {
         meta: options,
         payload: err
       })
+      if (options.onGlobalError) options.onGlobalError(err, res)
       if (options.onError) options.onError(err, res)
       return reject(err)
     }


### PR DESCRIPTION
This adds support for a `options.onGlobalError` to be added to the options sent via `redux-sutro`:
```js
{
  api: createAPIActions(state.get('resources'), { onGlobalError: (e) => errorhandler(e) })
}
```